### PR TITLE
Feature/rework settings

### DIFF
--- a/SitecoreEzImporter.Tests/App.config
+++ b/SitecoreEzImporter.Tests/App.config
@@ -62,6 +62,30 @@
   
             </dependentAssembly>
   
+            <dependentAssembly>
+  
+                 <assemblyIdentity name="NSubstitute" publicKeyToken="92dd2e9066daa5ca" culture="neutral" />
+  
+                 <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
+  
+            </dependentAssembly>
+  
+            <dependentAssembly>
+  
+                 <assemblyIdentity name="AutoFixture.Xunit2" publicKeyToken="b24654c590009d4f" culture="neutral" />
+  
+                 <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0" />
+  
+            </dependentAssembly>
+  
+            <dependentAssembly>
+  
+                 <assemblyIdentity name="AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
+  
+                 <bindingRedirect oldVersion="0.0.0.0-4.8.0.0" newVersion="4.8.0.0" />
+  
+            </dependentAssembly>
+  
        </assemblyBinding>
   
   </runtime>

--- a/SitecoreEzImporter.Tests/AutoNSubstituteDataAttribute.cs
+++ b/SitecoreEzImporter.Tests/AutoNSubstituteDataAttribute.cs
@@ -1,0 +1,15 @@
+﻿using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
+
+namespace EzImporter.Tests
+{
+    public class AutoNSubstituteDataAttribute : AutoDataAttribute
+    {
+        public AutoNSubstituteDataAttribute()
+            : base(() => new Fixture().Customize(new AutoNSubstituteCustomization()))
+        {
+
+        }
+    }
+}

--- a/SitecoreEzImporter.Tests/Pipelines/ImportItems/ValidateArgsTests.cs
+++ b/SitecoreEzImporter.Tests/Pipelines/ImportItems/ValidateArgsTests.cs
@@ -1,17 +1,27 @@
-﻿using EzImporter.Pipelines.ImportItems;
+﻿using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
+using EzImporter.Pipelines.ImportItems;
+using EzImporter.Tests;
+using FluentAssertions;
+using Sitecore.Abstractions;
 using Xunit;
 
 namespace SitecoreEzImporter.Tests.Pipelines.ImportItems
 {
     public class ValidateArgsTests
     {
-        [Fact]
-        public void Process_Aborted()
+        [Theory, AutoNSubstituteData]
+        public void Process_WhenNoStream_AbortsPipeline(BaseLog log)
         {
-            var validateArgs = new ValidateArgs();
+            // Arrange
+            var validateArgs = new ValidateArgs(log);
             var args = new ImportItemsArgs { FileStream = null };
+
+            // Act
             validateArgs.Process(args);
-            Assert.True(args.Aborted);
+
+            // Assert
+            args.Aborted.Should().BeTrue();       
         }
     }
 }

--- a/SitecoreEzImporter.Tests/Pipelines/ImportItems/ValidateItemNamesTests.cs
+++ b/SitecoreEzImporter.Tests/Pipelines/ImportItems/ValidateItemNamesTests.cs
@@ -53,15 +53,6 @@ namespace SitecoreEzImporter.Tests.Pipelines.ImportItems
         }
 
         [Theory, AutoData]
-        public void ValidateItemNames_Success(string value)
-        {
-            var validateItemNamesProcessor = new ValidateItemNames();
-            var importItem = new ItemDto(value);
-            validateItemNamesProcessor.ValidateName(importItem);
-            Assert.Empty(validateItemNamesProcessor.Errors);
-        }
-
-        [Theory, AutoData]
         public void Process_WhenImportItemHasInvalidName_AbortsPipeline(string invalidItemName, string suggestedItemName)
         {
             // Arrange

--- a/SitecoreEzImporter.Tests/SitecoreEzImporter.Tests.csproj
+++ b/SitecoreEzImporter.Tests/SitecoreEzImporter.Tests.csproj
@@ -145,7 +145,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoNSubstituteDataAttribute.cs" />
-    <Compile Include="Configuration\DefaultImportOptionsFactoryTests.cs" />
     <Compile Include="Extensions\DataTableExtensionsTests.cs" />
     <Compile Include="Pipelines\ImportItems\ValidateArgsTests.cs" />
     <Compile Include="Pipelines\ImportItems\ValidateItemNamesTests.cs" />

--- a/SitecoreEzImporter.Tests/SitecoreEzImporter.Tests.csproj
+++ b/SitecoreEzImporter.Tests/SitecoreEzImporter.Tests.csproj
@@ -9,7 +9,7 @@
     <ProjectGuid>{77C351A2-3C37-4497-8514-CF50DCA86F3E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Sitecore.EzImporter.Tests</RootNamespace>
+    <RootNamespace>EzImporter.Tests</RootNamespace>
     <AssemblyName>Sitecore.EzImporter.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
@@ -38,8 +38,14 @@
     <Reference Include="AutoFixture, Version=4.8.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoFixture.4.8.0\lib\net452\AutoFixture.dll</HintPath>
     </Reference>
+    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.8.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoNSubstitute.4.8.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
+    </Reference>
     <Reference Include="AutoFixture.Xunit2, Version=4.8.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoFixture.Xunit2.4.8.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.2.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Fare, Version=2.1.0.0, Culture=neutral, PublicKeyToken=ea68d375bf33a7c8, processorArchitecture=MSIL">
       <HintPath>..\packages\Fare.2.1.1\lib\net35\Fare.dll</HintPath>
@@ -69,11 +75,8 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.9.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.9.2.0\lib\net45\NSubstitute.dll</HintPath>
-    </Reference>
-    <Reference Include="Sitecore.FakeDb, Version=1.7.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Sitecore.FakeDb.1.7.4\lib\net45\Sitecore.FakeDb.dll</HintPath>
+    <Reference Include="NSubstitute, Version=3.1.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.3.1.0\lib\net46\NSubstitute.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Sitecore.Kernel.8.2.170728\lib\NET452\Sitecore.Kernel.dll</HintPath>
@@ -95,6 +98,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Linq, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Linq.4.1.0\lib\net463\System.Linq.dll</HintPath>
@@ -115,6 +119,9 @@
       <HintPath>..\packages\System.Runtime.Extensions.4.1.0\lib\net462\System.Runtime.Extensions.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -137,6 +144,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutoNSubstituteDataAttribute.cs" />
+    <Compile Include="Configuration\DefaultImportOptionsFactoryTests.cs" />
     <Compile Include="Extensions\DataTableExtensionsTests.cs" />
     <Compile Include="Pipelines\ImportItems\ValidateArgsTests.cs" />
     <Compile Include="Pipelines\ImportItems\ValidateItemNamesTests.cs" />

--- a/SitecoreEzImporter.Tests/packages.config
+++ b/SitecoreEzImporter.Tests/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AutoFixture" version="4.8.0" targetFramework="net472" />
+  <package id="AutoFixture.AutoNSubstitute" version="4.8.0" targetFramework="net472" />
   <package id="AutoFixture.Xunit2" version="4.8.0" targetFramework="net472" />
+  <package id="Castle.Core" version="4.2.0" targetFramework="net472" />
   <package id="Fare" version="2.1.1" targetFramework="net472" />
   <package id="FluentAssertions" version="5.6.0" targetFramework="net472" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net452" />
@@ -9,9 +11,8 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package id="NSubstitute" version="1.9.2.0" targetFramework="net472" />
+  <package id="NSubstitute" version="3.1.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />
-  <package id="Sitecore.FakeDb" version="1.7.4" targetFramework="net472" />
   <package id="Sitecore.Kernel" version="8.2.170728" targetFramework="net472" developmentDependency="true" />
   <package id="Sitecore.Logging" version="8.2.170728" targetFramework="net472" developmentDependency="true" />
   <package id="Sitecore.Logging.Client" version="8.2.170728" targetFramework="net472" developmentDependency="true" />
@@ -30,6 +31,7 @@
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net472" />
   <package id="System.Threading" version="4.0.11" targetFramework="net472" />
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.3.0" targetFramework="net472" />
   <package id="xunit" version="2.4.1" targetFramework="net472" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net472" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net472" />

--- a/SitecoreEzImporter/Configuration/DefaultImportOptionsFactory.cs
+++ b/SitecoreEzImporter/Configuration/DefaultImportOptionsFactory.cs
@@ -2,7 +2,7 @@
 
 namespace EzImporter.Configuration
 {
-    public class DefaultImportOptionsFactory: ImportOptionsFactory
+    public class DefaultImportOptionsFactory : ImportOptionsFactory
     {
         public override IImportOptions GetDefaultImportOptions()
         {
@@ -26,15 +26,30 @@ namespace EzImporter.Configuration
                 ExistingItemHandling = existingItemHandling,
                 InvalidLinkHandling = invalidLinkHandling,
                 MultipleValuesImportSeparator =
-                    Sitecore.Configuration.Settings.GetSetting("EzImporter.MultipleValuesImportSeparator", "|"),
+                    GetSetting("EzImporter.MultipleValuesImportSeparator", "|"),
                 TreePathValuesImportSeparator =
-                    Sitecore.Configuration.Settings.GetSetting("EzImporter.TreePathValuesImportSeparator", @"\"),
+                    GetSetting("EzImporter.TreePathValuesImportSeparator", @"\"),
                 CsvDelimiter = new[]
                 {
-                    Sitecore.Configuration.Settings.GetSetting("EzImporter.CsvDelimiter", ",")
+                    GetSetting("EzImporter.CsvDelimiter", ",")
                 },
-                FirstRowAsColumnNames = Sitecore.Configuration.Settings.GetBoolSetting("EzImporter.FirstRowAsColumnNames", true)
+                FirstRowAsColumnNames = GetBoolSetting("EzImporter.FirstRowAsColumnNames", true)
             };
         }
+
+        protected TEnum GetEnum<TEnum>(string settingName, TEnum defaultValue) where TEnum : struct
+        {
+            var textValue = GetSetting(settingName, defaultValue: string.Empty);
+
+            if (!Enum.TryParse(textValue, out TEnum parsed))
+            {
+                parsed = defaultValue;
+            }
+            return parsed;
+        }
+
+        internal virtual string GetSetting(string settingName, string defaultValue) => Sitecore.Configuration.Settings.GetSetting(settingName, defaultValue);
+
+        internal virtual bool GetBoolSetting(string settingName, bool defaultValue) => Sitecore.Configuration.Settings.GetBoolSetting(settingName, defaultValue);
     }
 }

--- a/SitecoreEzImporter/Configuration/DefaultImportOptionsFactory.cs
+++ b/SitecoreEzImporter/Configuration/DefaultImportOptionsFactory.cs
@@ -6,34 +6,14 @@ namespace EzImporter.Configuration
     {
         public override IImportOptions GetDefaultImportOptions()
         {
-            var value = Sitecore.Configuration.Settings.GetSetting("EzImporter.ExistingItemHandling", "AddVersion");
-            ExistingItemHandling existingItemHandling;
-            if (!Enum.TryParse<ExistingItemHandling>(value, out existingItemHandling))
-            {
-                existingItemHandling = EzImporter.ExistingItemHandling.AddVersion;
-            }
-
-            var invalidLinkHandlingValue = Sitecore.Configuration.Settings.GetSetting("EzImporter.InvalidLinkHandling",
-                "SetBroken");
-            InvalidLinkHandling invalidLinkHandling;
-            if (!Enum.TryParse<InvalidLinkHandling>(invalidLinkHandlingValue, out invalidLinkHandling))
-            {
-                invalidLinkHandling = EzImporter.InvalidLinkHandling.SetBroken;
-            }
-
             return new ImportOptions
             {
-                ExistingItemHandling = existingItemHandling,
-                InvalidLinkHandling = invalidLinkHandling,
-                MultipleValuesImportSeparator =
-                    GetSetting("EzImporter.MultipleValuesImportSeparator", "|"),
-                TreePathValuesImportSeparator =
-                    GetSetting("EzImporter.TreePathValuesImportSeparator", @"\"),
-                CsvDelimiter = new[]
-                {
-                    GetSetting("EzImporter.CsvDelimiter", ",")
-                },
-                FirstRowAsColumnNames = GetBoolSetting("EzImporter.FirstRowAsColumnNames", true)
+                ExistingItemHandling = GetEnum(SettingNames.ExistingItemHandling, defaultValue: ExistingItemHandling.AddVersion),
+                InvalidLinkHandling = GetEnum(SettingNames.InvalidLinkHandling, defaultValue: InvalidLinkHandling.SetBroken),
+                MultipleValuesImportSeparator = GetSetting(SettingNames.MultipleValuesImportSeparator, "|"),
+                TreePathValuesImportSeparator = GetSetting(SettingNames.TreePathValuesImportSeparator, @"\"),
+                CsvDelimiter = new[] { GetSetting(SettingNames.CsvDelimiter, ",") },
+                FirstRowAsColumnNames = GetBoolSetting(SettingNames.FirstRowAsColumnNames, defaultValue: true)
             };
         }
 
@@ -41,11 +21,7 @@ namespace EzImporter.Configuration
         {
             var textValue = GetSetting(settingName, defaultValue: string.Empty);
 
-            if (!Enum.TryParse(textValue, out TEnum parsed))
-            {
-                parsed = defaultValue;
-            }
-            return parsed;
+            return Enum.TryParse(textValue, out TEnum parsed) ? parsed : defaultValue;
         }
 
         internal virtual string GetSetting(string settingName, string defaultValue) => Sitecore.Configuration.Settings.GetSetting(settingName, defaultValue);

--- a/SitecoreEzImporter/SettingNames.cs
+++ b/SitecoreEzImporter/SettingNames.cs
@@ -1,0 +1,38 @@
+﻿namespace EzImporter
+{
+    /// <summary>
+    /// Names for module-specific settings.
+    /// </summary>
+    public class SettingNames
+    {
+        /// <summary>
+        /// Defaults to: "EzImporter.ExistingItemHandling"
+        /// </summary>
+        public static readonly string ExistingItemHandling = "EzImporter.ExistingItemHandling";
+
+        /// <summary>
+        /// Defaults to: "EzImporter.InvalidLinkHandling"
+        /// </summary>
+        public static readonly string InvalidLinkHandling = "EzImporter.InvalidLinkHandling";
+
+        /// <summary>
+        /// Defaults to: "EzImporter.MultipleValuesImportSeparator"
+        /// </summary>
+        public static readonly string MultipleValuesImportSeparator = "EzImporter.MultipleValuesImportSeparator";
+
+        /// <summary>
+        /// Defaults to: "EzImporter.TreePathValuesImportSeparator"
+        /// </summary>
+        public static readonly string TreePathValuesImportSeparator = "EzImporter.TreePathValuesImportSeparator";
+
+        /// <summary>
+        /// Defaults to: "EzImporter.CsvDelimiter"
+        /// </summary>
+        public static readonly string CsvDelimiter = "EzImporter.CsvDelimiter";
+
+        /// <summary>
+        /// Defaults to: "EzImporter.FirstRowAsColumnNames"
+        /// </summary>
+        public static readonly string  FirstRowAsColumnNames= "EzImporter.FirstRowAsColumnNames";
+    }
+}

--- a/SitecoreEzImporter/SitecoreEzImporter.csproj
+++ b/SitecoreEzImporter/SitecoreEzImporter.csproj
@@ -187,6 +187,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Pipelines\ImportItems\ValidateItemNames.cs" />
+    <Compile Include="SettingNames.cs" />
     <Compile Include="Tasks\Import.cs" />
     <Compile Include="Commands\LaunchEzImporter.cs" />
     <Compile Include="Configuration\ImportOptionsFactory.cs" />

--- a/SitecoreEzImporter/SitecoreEzImporter.csproj
+++ b/SitecoreEzImporter/SitecoreEzImporter.csproj
@@ -179,6 +179,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configuration\DefaultImportOptionsFactory.cs" />
+    <Compile Include="Configuration\ImporterModuleConfiguration.cs" />
     <Compile Include="Services\ServicesConfigurator.cs" />
     <Compile Include="FieldUpdater\DefaultFieldUpdateManager.cs" />
     <Compile Include="Map\ItemDto.cs" />
@@ -230,7 +231,6 @@
     <Compile Include="Pipelines\ImportItems\ValidateArgs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Pipelines\ImportItems\ImportItemsArgs.cs" />
-    <Compile Include="Configuration\Settings.cs" />
     <Compile Include="Tasks\ImportCommandItem.cs" />
     <Compile Include="ItemValidNameHelper.cs" />
     <Compile Include="TextConstants.cs" />

--- a/SitecoreEzImporter/TextConstants.cs
+++ b/SitecoreEzImporter/TextConstants.cs
@@ -13,7 +13,6 @@ namespace EzImporter
         /// </summary>
         public static readonly string ContentDatabaseName = "master";
 
-
         public static class PipelineNames
         {
             /// <summary>


### PR DESCRIPTION
Make configuration part mockable. 
In later platform versions, the BaseSettings abstraction exists, while currently we have to mimic similar API to ease future move (if any)